### PR TITLE
Improvement: Add underlying werror safe params to health check's params if the health check is driven by errors

### DIFF
--- a/changelog/@unreleased/pr-5.v2.yml
+++ b/changelog/@unreleased/pr-5.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description:  Add werror error string printing as a param for health checks driven by errors
+  description:  Add underlying werror safe params to health check's params if the health check is driven by errors
   links:
   - https://github.com/palantir/witchcraft-go-health/pull/5

--- a/changelog/@unreleased/pr-5.v2.yml
+++ b/changelog/@unreleased/pr-5.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description:  Add werror error string printing as a param for health checks driven by errors
+  links:
+  - https://github.com/palantir/witchcraft-go-health/pull/5

--- a/sources/periodic/source.go
+++ b/sources/periodic/source.go
@@ -203,7 +203,7 @@ func newDefaultHealthCheckSource(checkType health.CheckType, poll func() error) 
 						Type:    checkType,
 						State:   health.New_HealthState(health.HealthState_ERROR),
 						Message: stringPtr(err.Error()),
-						Params:  sources.ErrorToUnderlyingSafeParamsMap(err),
+						Params:  sources.SafeParamsFromError(err),
 					}
 				}
 				return &health.HealthCheckResult{

--- a/sources/periodic/source.go
+++ b/sources/periodic/source.go
@@ -17,11 +17,11 @@ package periodic
 import (
 	"context"
 	"fmt"
-	"github.com/palantir/witchcraft-go-health/sources"
 	"sync"
 	"time"
 
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-health/sources"
 	"github.com/palantir/witchcraft-go-health/status"
 	"github.com/palantir/witchcraft-go-logging/wlog/wapp"
 )
@@ -203,7 +203,7 @@ func newDefaultHealthCheckSource(checkType health.CheckType, poll func() error) 
 						Type:    checkType,
 						State:   health.New_HealthState(health.HealthState_ERROR),
 						Message: stringPtr(err.Error()),
-						Params: sources.ErrorToRichParamsMap(err),
+						Params:  sources.ErrorToRichParamsMap(err),
 					}
 				}
 				return &health.HealthCheckResult{

--- a/sources/periodic/source.go
+++ b/sources/periodic/source.go
@@ -203,7 +203,7 @@ func newDefaultHealthCheckSource(checkType health.CheckType, poll func() error) 
 						Type:    checkType,
 						State:   health.New_HealthState(health.HealthState_ERROR),
 						Message: stringPtr(err.Error()),
-						Params:  sources.ErrorToRichParamsMap(err),
+						Params:  sources.ErrorToUnderlyingSafeParamsMap(err),
 					}
 				}
 				return &health.HealthCheckResult{

--- a/sources/periodic/source.go
+++ b/sources/periodic/source.go
@@ -17,6 +17,7 @@ package periodic
 import (
 	"context"
 	"fmt"
+	"github.com/palantir/witchcraft-go-health/sources"
 	"sync"
 	"time"
 
@@ -202,6 +203,7 @@ func newDefaultHealthCheckSource(checkType health.CheckType, poll func() error) 
 						Type:    checkType,
 						State:   health.New_HealthState(health.HealthState_ERROR),
 						Message: stringPtr(err.Error()),
+						Params: sources.ErrorToRichParamsMap(err),
 					}
 				}
 				return &health.HealthCheckResult{

--- a/sources/store/keyed_error_source.go
+++ b/sources/store/keyed_error_source.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"sync"
 
-	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-health/sources"
 	"github.com/palantir/witchcraft-go-health/status"
@@ -84,7 +83,7 @@ func (k *keyedErrorHealthCheckSource) HealthStatus(ctx context.Context) health.H
 	}
 	params := map[string]interface{}{}
 	for key, err := range k.keyedErrors {
-		params[key] = werror.GenerateErrorString(err, false)
+		params[key] = err.Error()
 		for k, v := range sources.ErrorToUnderlyingSafeParamsMap(err) {
 			params[k] = v
 		}

--- a/sources/store/keyed_error_source.go
+++ b/sources/store/keyed_error_source.go
@@ -16,9 +16,9 @@ package store
 
 import (
 	"context"
-	werror "github.com/palantir/witchcraft-go-error"
 	"sync"
 
+	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-health/status"
 )

--- a/sources/store/keyed_error_source.go
+++ b/sources/store/keyed_error_source.go
@@ -16,6 +16,7 @@ package store
 
 import (
 	"context"
+	werror "github.com/palantir/witchcraft-go-error"
 	"sync"
 
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
@@ -82,7 +83,7 @@ func (k *keyedErrorHealthCheckSource) HealthStatus(ctx context.Context) health.H
 	}
 	params := make(map[string]interface{}, len(k.keyedErrors))
 	for key, err := range k.keyedErrors {
-		params[key] = err.Error()
+		params[key] = werror.GenerateErrorString(err, false)
 	}
 	return health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{

--- a/sources/store/keyed_error_source.go
+++ b/sources/store/keyed_error_source.go
@@ -16,6 +16,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
@@ -84,8 +85,8 @@ func (k *keyedErrorHealthCheckSource) HealthStatus(ctx context.Context) health.H
 	params := map[string]interface{}{}
 	for key, err := range k.keyedErrors {
 		params[key] = err.Error()
-		for k, v := range sources.ErrorToUnderlyingSafeParamsMap(err) {
-			params[k] = v
+		for k, v := range sources.SafeParamsFromError(err) {
+			params[fmt.Sprintf("%s-%s", key, k)] = v
 		}
 	}
 	return health.HealthStatus{

--- a/sources/store/keyed_error_source.go
+++ b/sources/store/keyed_error_source.go
@@ -20,6 +20,7 @@ import (
 
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-health/sources"
 	"github.com/palantir/witchcraft-go-health/status"
 )
 
@@ -81,9 +82,12 @@ func (k *keyedErrorHealthCheckSource) HealthStatus(ctx context.Context) health.H
 			},
 		}
 	}
-	params := make(map[string]interface{}, len(k.keyedErrors))
+	params := map[string]interface{}{}
 	for key, err := range k.keyedErrors {
 		params[key] = werror.GenerateErrorString(err, false)
+		for k, v := range sources.ErrorToUnderlyingSafeParamsMap(err) {
+			params[k] = v
+		}
 	}
 	return health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{

--- a/sources/store/keyed_error_source_test.go
+++ b/sources/store/keyed_error_source_test.go
@@ -30,16 +30,17 @@ var (
 
 func TestKeyedMessengerHealthStateError(t *testing.T) {
 	keyedErrorSource := NewKeyedErrorHealthCheckSource("TEST", testMessage)
-	keyedErrorSource.Submit("1", fmt.Errorf("error message 1"))
+	keyedErrorSource.Submit("1", werror.Error("error message 1", werror.SafeParam("foo", "baz")))
 	keyedErrorSource.Submit("2", werror.Error("error message 2", werror.SafeParam("foo", "bar")))
 	assert.Equal(t, health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{
 			"TEST": {
 				Message: &testMessage,
 				Params: map[string]interface{}{
-					"1":   "error message 1",
-					"2":   "error message 2",
-					"foo": "bar",
+					"1":     "error message 1",
+					"2":     "error message 2",
+					"1-foo": "baz",
+					"2-foo": "bar",
 				},
 				State: health.New_HealthState(health.HealthState_ERROR),
 				Type:  "TEST",

--- a/sources/store/keyed_error_source_test.go
+++ b/sources/store/keyed_error_source_test.go
@@ -38,7 +38,7 @@ func TestKeyedMessengerHealthStateError(t *testing.T) {
 				Message: &testMessage,
 				Params: map[string]interface{}{
 					"1":   "error message 1",
-					"2":   "error message 2 foo:bar\n\ngithub.com/palantir/witchcraft-go-health/sources/store.TestKeyedMessengerHealthStateError\n\t/Users/ksimons/go/src/github.com/palantir/witchcraft-go-health/sources/store/keyed_error_source_test.go:34\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1039\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373",
+					"2":   "error message 2",
 					"foo": "bar",
 				},
 				State: health.New_HealthState(health.HealthState_ERROR),

--- a/sources/store/keyed_error_source_test.go
+++ b/sources/store/keyed_error_source_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
 	"github.com/stretchr/testify/assert"
 )
@@ -30,14 +31,15 @@ var (
 func TestKeyedMessengerHealthStateError(t *testing.T) {
 	keyedErrorSource := NewKeyedErrorHealthCheckSource("TEST", testMessage)
 	keyedErrorSource.Submit("1", fmt.Errorf("error message 1"))
-	keyedErrorSource.Submit("2", fmt.Errorf("error message 2"))
+	keyedErrorSource.Submit("2", werror.Error("error message 2", werror.SafeParam("foo", "bar")))
 	assert.Equal(t, health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{
 			"TEST": {
 				Message: &testMessage,
 				Params: map[string]interface{}{
-					"1": "error message 1",
-					"2": "error message 2",
+					"1":   "error message 1",
+					"2":   "error message 2 foo:bar\n\ngithub.com/palantir/witchcraft-go-health/sources/store.TestKeyedMessengerHealthStateError\n\t/Users/ksimons/go/src/github.com/palantir/witchcraft-go-health/sources/store/keyed_error_source_test.go:34\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1039\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373",
+					"foo": "bar",
 				},
 				State: health.New_HealthState(health.HealthState_ERROR),
 				Type:  "TEST",

--- a/sources/utils.go
+++ b/sources/utils.go
@@ -47,7 +47,8 @@ func HealthyHealthCheckResult(checkType health.CheckType) health.HealthCheckResu
 	}
 }
 
-func ErrorToUnderlyingSafeParamsMap(err error) map[string]interface{} {
+// SafeParamsFromError returns the safeParam map from the given error
+func SafeParamsFromError(err error) map[string]interface{} {
 	safeParams, _ := werror.ParamsFromError(err)
 	return safeParams
 }

--- a/sources/utils.go
+++ b/sources/utils.go
@@ -25,7 +25,7 @@ func UnhealthyHealthCheckResult(checkType health.CheckType, message string, para
 		Type:    checkType,
 		State:   health.New_HealthState(health.HealthState_ERROR),
 		Message: &message,
-		Params: params,
+		Params:  params,
 	}
 }
 
@@ -35,7 +35,7 @@ func RepairingHealthCheckResult(checkType health.CheckType, message string, para
 		Type:    checkType,
 		State:   health.New_HealthState(health.HealthState_REPAIRING),
 		Message: &message,
-		Params: params,
+		Params:  params,
 	}
 }
 

--- a/sources/utils.go
+++ b/sources/utils.go
@@ -47,8 +47,7 @@ func HealthyHealthCheckResult(checkType health.CheckType) health.HealthCheckResu
 	}
 }
 
-func ErrorToRichParamsMap(err error) map[string]interface{} {
-	return map[string]interface{}{
-		"richErrorMessage": werror.GenerateErrorString(err, false),
-	}
+func ErrorToUnderlyingSafeParamsMap(err error) map[string]interface{} {
+	safeParams, _ := werror.ParamsFromError(err)
+	return safeParams
 }

--- a/sources/utils.go
+++ b/sources/utils.go
@@ -15,24 +15,27 @@
 package sources
 
 import (
+	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
 )
 
 // UnhealthyHealthCheckResult returns an unhealthy health check result with type checkType and message message.
-func UnhealthyHealthCheckResult(checkType health.CheckType, message string) health.HealthCheckResult {
+func UnhealthyHealthCheckResult(checkType health.CheckType, message string, params map[string]interface{}) health.HealthCheckResult {
 	return health.HealthCheckResult{
 		Type:    checkType,
 		State:   health.New_HealthState(health.HealthState_ERROR),
 		Message: &message,
+		Params: params,
 	}
 }
 
 // RepairingHealthCheckResult returns an repairing health check result with type checkType and message message.
-func RepairingHealthCheckResult(checkType health.CheckType, message string) health.HealthCheckResult {
+func RepairingHealthCheckResult(checkType health.CheckType, message string, params map[string]interface{}) health.HealthCheckResult {
 	return health.HealthCheckResult{
 		Type:    checkType,
 		State:   health.New_HealthState(health.HealthState_REPAIRING),
 		Message: &message,
+		Params: params,
 	}
 }
 
@@ -41,5 +44,11 @@ func HealthyHealthCheckResult(checkType health.CheckType) health.HealthCheckResu
 	return health.HealthCheckResult{
 		Type:  checkType,
 		State: health.New_HealthState(health.HealthState_HEALTHY),
+	}
+}
+
+func ErrorToRichParamsMap(err error) map[string]interface{} {
+	return map[string]interface{}{
+		"richErrorMessage": werror.GenerateErrorString(err, false),
 	}
 }

--- a/sources/window/error_source.go
+++ b/sources/window/error_source.go
@@ -195,9 +195,9 @@ func (h *healthyIfNotAllErrorsSource) HealthStatus(ctx context.Context) health.H
 		healthCheckResult = sources.HealthyHealthCheckResult(h.checkType)
 	} else if h.hasErrorInWindow() {
 		if h.lastErrorTime.Before(h.repairingDeadline) {
-			healthCheckResult = sources.RepairingHealthCheckResult(h.checkType, h.lastError.Error(), sources.ErrorToUnderlyingSafeParamsMap(h.lastError))
+			healthCheckResult = sources.RepairingHealthCheckResult(h.checkType, h.lastError.Error(), sources.SafeParamsFromError(h.lastError))
 		} else {
-			healthCheckResult = sources.UnhealthyHealthCheckResult(h.checkType, h.lastError.Error(), sources.ErrorToUnderlyingSafeParamsMap(h.lastError))
+			healthCheckResult = sources.UnhealthyHealthCheckResult(h.checkType, h.lastError.Error(), sources.SafeParamsFromError(h.lastError))
 		}
 	} else {
 		healthCheckResult = sources.HealthyHealthCheckResult(h.checkType)

--- a/sources/window/error_source.go
+++ b/sources/window/error_source.go
@@ -195,9 +195,9 @@ func (h *healthyIfNotAllErrorsSource) HealthStatus(ctx context.Context) health.H
 		healthCheckResult = sources.HealthyHealthCheckResult(h.checkType)
 	} else if h.hasErrorInWindow() {
 		if h.lastErrorTime.Before(h.repairingDeadline) {
-			healthCheckResult = sources.RepairingHealthCheckResult(h.checkType, h.lastError.Error())
+			healthCheckResult = sources.RepairingHealthCheckResult(h.checkType, h.lastError.Error(), sources.ErrorToRichParamsMap(h.lastError))
 		} else {
-			healthCheckResult = sources.UnhealthyHealthCheckResult(h.checkType, h.lastError.Error())
+			healthCheckResult = sources.UnhealthyHealthCheckResult(h.checkType, h.lastError.Error(), sources.ErrorToRichParamsMap(h.lastError))
 		}
 	} else {
 		healthCheckResult = sources.HealthyHealthCheckResult(h.checkType)

--- a/sources/window/error_source.go
+++ b/sources/window/error_source.go
@@ -195,9 +195,9 @@ func (h *healthyIfNotAllErrorsSource) HealthStatus(ctx context.Context) health.H
 		healthCheckResult = sources.HealthyHealthCheckResult(h.checkType)
 	} else if h.hasErrorInWindow() {
 		if h.lastErrorTime.Before(h.repairingDeadline) {
-			healthCheckResult = sources.RepairingHealthCheckResult(h.checkType, h.lastError.Error(), sources.ErrorToRichParamsMap(h.lastError))
+			healthCheckResult = sources.RepairingHealthCheckResult(h.checkType, h.lastError.Error(), sources.ErrorToUnderlyingSafeParamsMap(h.lastError))
 		} else {
-			healthCheckResult = sources.UnhealthyHealthCheckResult(h.checkType, h.lastError.Error(), sources.ErrorToRichParamsMap(h.lastError))
+			healthCheckResult = sources.UnhealthyHealthCheckResult(h.checkType, h.lastError.Error(), sources.ErrorToUnderlyingSafeParamsMap(h.lastError))
 		}
 	} else {
 		healthCheckResult = sources.HealthyHealthCheckResult(h.checkType)

--- a/sources/window/error_source_test.go
+++ b/sources/window/error_source_test.go
@@ -73,7 +73,6 @@ func TestUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 				source.Submit(err)
 			}
 			actualStatus := source.HealthStatus(context.Background())
-			// We check the param keys only
 			expectedStatus := health.HealthStatus{
 				Checks: map[health.CheckType]health.HealthCheckResult{
 					testCheckType: testCase.expectedCheck,

--- a/sources/window/error_source_test.go
+++ b/sources/window/error_source_test.go
@@ -60,7 +60,9 @@ func TestUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 				werror.ErrorWithContextParams(context.Background(), "Error #2"),
 				nil,
 			},
-			expectedCheck: sources.UnhealthyHealthCheckResult(testCheckType, "Error #2"),
+			expectedCheck: sources.UnhealthyHealthCheckResult(testCheckType, "Error #2", map[string]interface{}{
+				"richErrorMessage": "Error #2\n\ngithub.com/palantir/witchcraft-go-health/sources/window.TestUnhealthyIfAtLeastOneErrorSource\n\t/Users/ksimons/go/src/github.com/palantir/witchcraft-go-health/sources/window/error_source_test.go:60\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1039\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373",
+			}),
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -118,7 +120,9 @@ func TestHealthyIfNotAllErrorsSource(t *testing.T) {
 				werror.ErrorWithContextParams(context.Background(), "Error #1"),
 				werror.ErrorWithContextParams(context.Background(), "Error #2"),
 			},
-			expectedCheck: sources.UnhealthyHealthCheckResult(testCheckType, "Error #2"),
+			expectedCheck: sources.UnhealthyHealthCheckResult(testCheckType, "Error #2", map[string]interface{}{
+				"richErrorMessage": "Error #2\n\ngithub.com/palantir/witchcraft-go-health/sources/window.TestHealthyIfNotAllErrorsSource\n\t/Users/ksimons/go/src/github.com/palantir/witchcraft-go-health/sources/window/error_source_test.go:121\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1039\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373",
+			}),
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/sources/window/error_source_test.go
+++ b/sources/window/error_source_test.go
@@ -57,11 +57,11 @@ func TestUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 				nil,
 				werror.ErrorWithContextParams(context.Background(), "Error #1"),
 				nil,
-				werror.ErrorWithContextParams(context.Background(), "Error #2"),
+				werror.ErrorWithContextParams(context.Background(), "Error #2", werror.SafeParam("foo", "bar")),
 				nil,
 			},
 			expectedCheck: sources.UnhealthyHealthCheckResult(testCheckType, "Error #2", map[string]interface{}{
-				"richErrorMessage": "Error #2\n\ngithub.com/palantir/witchcraft-go-health/sources/window.TestUnhealthyIfAtLeastOneErrorSource\n\t/Users/ksimons/go/src/github.com/palantir/witchcraft-go-health/sources/window/error_source_test.go:60\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1039\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373",
+				"foo": "bar",
 			}),
 		},
 	} {
@@ -73,6 +73,7 @@ func TestUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 				source.Submit(err)
 			}
 			actualStatus := source.HealthStatus(context.Background())
+			// We check the param keys only
 			expectedStatus := health.HealthStatus{
 				Checks: map[health.CheckType]health.HealthCheckResult{
 					testCheckType: testCase.expectedCheck,
@@ -118,10 +119,10 @@ func TestHealthyIfNotAllErrorsSource(t *testing.T) {
 			name: "unhealthy when there are only non nil items",
 			errors: []error{
 				werror.ErrorWithContextParams(context.Background(), "Error #1"),
-				werror.ErrorWithContextParams(context.Background(), "Error #2"),
+				werror.ErrorWithContextParams(context.Background(), "Error #2", werror.SafeParam("foo", "bar")),
 			},
 			expectedCheck: sources.UnhealthyHealthCheckResult(testCheckType, "Error #2", map[string]interface{}{
-				"richErrorMessage": "Error #2\n\ngithub.com/palantir/witchcraft-go-health/sources/window.TestHealthyIfNotAllErrorsSource\n\t/Users/ksimons/go/src/github.com/palantir/witchcraft-go-health/sources/window/error_source_test.go:121\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1039\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373",
+				"foo": "bar",
 			}),
 		},
 	} {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
- There are a number of health checks that are driven by errors. The params for these health checks are left emtpy

## After this PR
- The params map is populated with any underlying werror safe params on stored on the error or the underlying cause of the error
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

