### PR TITLE
Improvement: Add simple library helper for transforming HealthCheckSources

### DIFF
--- a/changelog/@unreleased/pr-5.v2.yml
+++ b/changelog/@unreleased/pr-5.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add simple library helper for transforming HealthCheckSources
+  links:
+  - https://github.com/palantir/witchcraft-go-health/pull/6

--- a/sources/transform/health_status_transformer_func.go
+++ b/sources/transform/health_status_transformer_func.go
@@ -28,7 +28,7 @@ type source struct {
 	healthCheckSource           status.HealthCheckSource
 }
 
-func NewSource(healthStatusTransformerFunc HealthStatusTransformerFunc, healthCheckSource status.HealthCheckSource) status.HealthCheckSource {
+func NewSource(healthCheckSource status.HealthCheckSource, healthStatusTransformerFunc HealthStatusTransformerFunc) status.HealthCheckSource {
 	return source{
 		healthStatusTransformerFunc: healthStatusTransformerFunc,
 		healthCheckSource:           healthCheckSource,

--- a/sources/transform/health_status_transformer_func.go
+++ b/sources/transform/health_status_transformer_func.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package transform
 
 import (

--- a/sources/transform/health_status_transformer_func_test.go
+++ b/sources/transform/health_status_transformer_func_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package transform
 
 import (

--- a/sources/transform/health_status_transformer_func_test.go
+++ b/sources/transform/health_status_transformer_func_test.go
@@ -1,0 +1,39 @@
+package transform
+
+import (
+	"context"
+	"testing"
+
+	werror "github.com/palantir/witchcraft-go-error"
+	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-health/sources/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSource(t *testing.T) {
+	expected := health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"a": {},
+		},
+	}
+	mapper := func(in health.HealthStatus) health.HealthStatus {
+		return expected
+	}
+	keyed := store.NewKeyedErrorHealthCheckSource("foo", "bar")
+	keyed.Submit("foo", werror.Error("err"))
+	source, err := NewSource(mapper, keyed)
+	assert.NoError(t, err)
+	status := source.HealthStatus(context.Background())
+	assert.Equal(t, expected, status)
+}
+
+func TestSourceNilChecks(t *testing.T) {
+	mapper := func(in health.HealthStatus) health.HealthStatus {
+		return health.HealthStatus{}
+	}
+	keyed := store.NewKeyedErrorHealthCheckSource("foo", "bar")
+	_, err := NewSource(nil, keyed)
+	assert.Error(t, err)
+	_, err = NewSource(mapper, nil)
+	assert.Error(t, err)
+}

--- a/sources/transform/health_status_transformer_func_test.go
+++ b/sources/transform/health_status_transformer_func_test.go
@@ -35,7 +35,7 @@ func TestSource(t *testing.T) {
 	}
 	keyed := store.NewKeyedErrorHealthCheckSource("foo", "bar")
 	keyed.Submit("foo", werror.Error("err"))
-	source := NewSource(mapper, keyed)
+	source := NewSource(keyed, mapper)
 	status := source.HealthStatus(context.Background())
 	assert.Equal(t, expected, status)
 }
@@ -45,7 +45,7 @@ func TestSourceNilChecks(t *testing.T) {
 		return health.HealthStatus{}
 	}
 	keyed := store.NewKeyedErrorHealthCheckSource("foo", "bar")
-	source := NewSource(nil, keyed)
+	source := NewSource(keyed, nil)
 	assert.Equal(t, source.HealthStatus(context.Background()), health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{
 			"foo": {
@@ -55,7 +55,7 @@ func TestSourceNilChecks(t *testing.T) {
 			},
 		},
 	})
-	source = NewSource(mapper, nil)
+	source = NewSource(nil, mapper)
 	assert.Equal(t, source.HealthStatus(context.Background()), health.HealthStatus{})
 }
 


### PR DESCRIPTION
- Add simple library helper for transforming HealthCheckSources
- This provides a simple way for consumer to transform health checks if needed

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

