### PR TITLE
feature: Add maximum error age option to window health checks

### DIFF
--- a/changelog/@unreleased/pr-14.v2.yml
+++ b/changelog/@unreleased/pr-14.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add maximum error age option to window health checks
+  links:
+  - https://github.com/palantir/witchcraft-go-health/pull/14


### PR DESCRIPTION
## Summary
This feature adds an option that allows users to specify a "maximum error age" to health check windows.
If the latest error within the window happened more than the max age ago, the health check returns repairing. This is also valid for multi key window checks.

The motivation for this is to deal with a corner case where if the last submission for a key was an error, the health check would report unhealthy in the period [last success + window, last error + window].

## Changelog
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add maximum error age option to window health checks
==COMMIT_MSG==

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/14)
<!-- Reviewable:end -->
