### PR TITLE
Add an option to configure the default health state value

### DIFF
--- a/changelog/@unreleased/pr-16.v2.yml
+++ b/changelog/@unreleased/pr-16.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add an option to configure the default health state value
+  links:
+  - https://github.com/palantir/witchcraft-go-health/pull/16

--- a/changelog/@unreleased/pr-16.v2.yml
+++ b/changelog/@unreleased/pr-16.v2.yml
@@ -1,5 +1,8 @@
 type: improvement
 improvement:
-  description: Add an option to configure the default health state value
+  description: |-
+    Adds the WithFailingHealthStateValue ErrorOption that allows the default health state value to be configured.
+
+    The ErrorHealthCheckSource would previously report an ERROR health state by default when the health status was computed, unless otherwise configured to downgrade to a REPAIRING state. Now the WithFailingHealthStateValue option can be used to configure the default health state value reported in cases where an ERROR health state is not ideal. This option only changes the default health state value and does not affect the logic to downgrade failures to a REPAIRING state.
   links:
   - https://github.com/palantir/witchcraft-go-health/pull/16

--- a/changelog/@unreleased/pr-16.v2.yml
+++ b/changelog/@unreleased/pr-16.v2.yml
@@ -1,5 +1,5 @@
-type: feature
-feature:
+type: improvement
+improvement:
   description: Add an option to configure the default health state value
   links:
   - https://github.com/palantir/witchcraft-go-health/pull/16

--- a/sources/window/error_options.go
+++ b/sources/window/error_options.go
@@ -135,7 +135,9 @@ func WithTimeProvider(timeProvider TimeProvider) ErrorOption {
 	}
 }
 
-// WithHealthStateValue overrides the default health state to use when setting the health check to unhealthy.
+// WithHealthStateValue overrides the default health state value used when computing the health status.
+// All options that reduce errors to a REPAIRING health state will continue to work as expected, as this option
+// strictly configures the base health state value before computing the full health status.
 // If not set, the default health state value will be an ERROR.
 func WithHealthStateValue(healthState health.HealthState_Value) ErrorOption {
 	return func(conf *errorSourceConfig) {

--- a/sources/window/error_options.go
+++ b/sources/window/error_options.go
@@ -135,11 +135,11 @@ func WithTimeProvider(timeProvider TimeProvider) ErrorOption {
 	}
 }
 
-// WithHealthStateValue overrides the default health state value used when computing the health status.
+// WithFailingHealthStateValue overrides the default health state value used when computing the health status in failure cases.
 // All options that reduce errors to a REPAIRING health state will continue to work as expected, as this option
 // strictly configures the base health state value before computing the full health status.
 // If not set, the default health state value will be an ERROR.
-func WithHealthStateValue(healthState health.HealthState_Value) ErrorOption {
+func WithFailingHealthStateValue(healthState health.HealthState_Value) ErrorOption {
 	return func(conf *errorSourceConfig) {
 		conf.healthState = healthState
 	}

--- a/sources/window/error_options.go
+++ b/sources/window/error_options.go
@@ -54,6 +54,7 @@ type errorSourceConfig struct {
 	requireFirstFullWindow bool
 	maxErrorAge            time.Duration
 	timeProvider           TimeProvider
+	healthState            health.HealthState_Value
 }
 
 func defaultErrorSourceConfig(checkType health.CheckType) errorSourceConfig {
@@ -65,6 +66,7 @@ func defaultErrorSourceConfig(checkType health.CheckType) errorSourceConfig {
 		requireFirstFullWindow: false,
 		maxErrorAge:            0,
 		timeProvider:           NewOrdinaryTimeProvider(),
+		healthState:            health.HealthState_ERROR,
 	}
 }
 
@@ -130,5 +132,13 @@ func WithMaximumErrorAge(maxErrorAge time.Duration) ErrorOption {
 func WithTimeProvider(timeProvider TimeProvider) ErrorOption {
 	return func(conf *errorSourceConfig) {
 		conf.timeProvider = timeProvider
+	}
+}
+
+// WithHealthStateValue overrides the default health state to use when setting the health check to unhealthy.
+// If not set, the default health state value will be an ERROR.
+func WithHealthStateValue(healthState health.HealthState_Value) ErrorOption {
+	return func(conf *errorSourceConfig) {
+		conf.healthState = healthState
 	}
 }

--- a/sources/window/error_source.go
+++ b/sources/window/error_source.go
@@ -49,6 +49,7 @@ type errorHealthCheckSource struct {
 	repairingGracePeriod time.Duration
 	repairingDeadline    time.Time
 	maxErrorAge          time.Duration
+	healthState          health.HealthState_Value
 }
 
 // MustNewErrorHealthCheckSource creates a new ErrorHealthCheckSource which will panic if any error is encountered.
@@ -93,6 +94,7 @@ func NewErrorHealthCheckSource(checkType health.CheckType, errorMode ErrorMode, 
 		repairingGracePeriod: conf.repairingGracePeriod,
 		repairingDeadline:    conf.timeProvider.Now(),
 		maxErrorAge:          conf.maxErrorAge,
+		healthState:          conf.healthState,
 	}
 
 	// If requireFirstFullWindow, extend the repairing deadline to one windowSize from now.
@@ -165,7 +167,7 @@ func (e *errorHealthCheckSource) getFailureResult() health.HealthCheckResult {
 	}
 	healthCheckResult := health.HealthCheckResult{
 		Type:    e.checkType,
-		State:   health.New_HealthState(health.HealthState_ERROR),
+		State:   health.New_HealthState(e.healthState),
 		Message: &e.checkMessage,
 		Params:  params,
 	}

--- a/sources/window/error_source_test.go
+++ b/sources/window/error_source_test.go
@@ -454,5 +454,4 @@ func TestHealthStateOverrideWithMaxAge(t *testing.T) {
 	checkResult, ok = healthStatus.Checks[testCheckType]
 	assert.True(t, ok)
 	assert.Equal(t, health.HealthState_REPAIRING, checkResult.State.Value())
-
 }

--- a/sources/window/error_source_test.go
+++ b/sources/window/error_source_test.go
@@ -396,8 +396,8 @@ func TestHealthyIfNoRecentErrorsSource(t *testing.T) {
 	}
 }
 
-// TestHealthStateValue asserts the behavior of overriding the default ERROR health state.
-func TestHealthStateValue(t *testing.T) {
+// TestFailingHealthStateValue asserts the behavior of overriding the default ERROR health state.
+func TestFailingHealthStateValue(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range []struct {
 		healthState health.HealthState_Value
@@ -412,7 +412,7 @@ func TestHealthStateValue(t *testing.T) {
 	} {
 		t.Run(string(tc.healthState), func(t *testing.T) {
 			source, err := NewErrorHealthCheckSource(testCheckType, HealthyIfNoRecentErrors,
-				WithHealthStateValue(tc.healthState),
+				WithFailingHealthStateValue(tc.healthState),
 				WithWindowSize(time.Hour),
 				WithTimeProvider(&offsetTimeProvider{}))
 			require.NoError(t, err)
@@ -433,7 +433,7 @@ func TestHealthStateOverrideWithMaxAge(t *testing.T) {
 	ctx := context.Background()
 	timeProvider := &offsetTimeProvider{}
 	source, err := NewErrorHealthCheckSource(testCheckType, HealthyIfNotAllErrors,
-		WithHealthStateValue(health.HealthState_WARNING),
+		WithFailingHealthStateValue(health.HealthState_WARNING),
 		WithWindowSize(windowSize),
 		WithMaximumErrorAge(windowSize/2),
 		WithTimeProvider(timeProvider))

--- a/sources/window/error_source_test.go
+++ b/sources/window/error_source_test.go
@@ -395,3 +395,64 @@ func TestHealthyIfNoRecentErrorsSource(t *testing.T) {
 		})
 	}
 }
+
+// TestHealthState asserts the behavior of overriding the default ERROR health state
+func TestHealthStateWarning(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		healthState health.HealthState_Value
+	}{
+		{health.HealthState_HEALTHY},
+		{health.HealthState_DEFERRING},
+		{health.HealthState_SUSPENDED},
+		{health.HealthState_REPAIRING},
+		{health.HealthState_WARNING},
+		{health.HealthState_ERROR},
+		{health.HealthState_TERMINAL},
+	} {
+		t.Run(string(tc.healthState), func(t *testing.T) {
+			source, err := NewErrorHealthCheckSource(testCheckType, HealthyIfNoRecentErrors,
+				WithHealthStateValue(tc.healthState),
+				WithWindowSize(time.Hour),
+				WithTimeProvider(&offsetTimeProvider{}))
+			require.NoError(t, err)
+
+			// submit the error and validate the health state value
+			source.Submit(werror.ErrorWithContextParams(ctx, "an error"))
+			healthStatus := source.HealthStatus(ctx)
+			checkResult, ok := healthStatus.Checks[testCheckType]
+			assert.True(t, ok)
+			assert.Equal(t, tc.healthState, checkResult.State.Value())
+		})
+	}
+}
+
+// TestHealthStateOverrideWithMaxAge ensures overriding the health state to something other than the default
+// does not affect the REPAIRING health state being set when using the maximum error age option.
+func TestHealthStateOverrideWithMaxAge(t *testing.T) {
+	ctx := context.Background()
+	timeProvider := &offsetTimeProvider{}
+	source, err := NewErrorHealthCheckSource(testCheckType, HealthyIfNotAllErrors,
+		WithHealthStateValue(health.HealthState_WARNING),
+		WithWindowSize(windowSize),
+		WithMaximumErrorAge(windowSize/2),
+		WithTimeProvider(timeProvider))
+	assert.NoError(t, err)
+
+	source.Submit(werror.ErrorWithContextParams(ctx, "an error"))
+
+	// Initial state before maximum error age is reached is expected to be WARNING
+	timeProvider.RestlessSleep(windowSize / 4)
+	healthStatus := source.HealthStatus(ctx)
+	checkResult, ok := healthStatus.Checks[testCheckType]
+	assert.True(t, ok)
+	assert.Equal(t, health.HealthState_WARNING, checkResult.State.Value())
+
+	// Sleeping for the maximum error age should now produce a REPAIRING health check
+	timeProvider.RestlessSleep(windowSize / 2)
+	healthStatus = source.HealthStatus(ctx)
+	checkResult, ok = healthStatus.Checks[testCheckType]
+	assert.True(t, ok)
+	assert.Equal(t, health.HealthState_REPAIRING, checkResult.State.Value())
+
+}

--- a/sources/window/error_source_test.go
+++ b/sources/window/error_source_test.go
@@ -396,8 +396,8 @@ func TestHealthyIfNoRecentErrorsSource(t *testing.T) {
 	}
 }
 
-// TestHealthState asserts the behavior of overriding the default ERROR health state
-func TestHealthStateWarning(t *testing.T) {
+// TestHealthStateValue asserts the behavior of overriding the default ERROR health state.
+func TestHealthStateValue(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range []struct {
 		healthState health.HealthState_Value


### PR DESCRIPTION
## Before this PR
The default health state was always set to an ERROR. However some situations may want to use other health status values, such as `WARNING` or always `REPAIRING` when an error is matched depending on the alerting infrastructure.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add an option to configure the default health state value
==COMMIT_MSG==

One concrete example where this is useful is for the TCP logger in witchcraft-go-server, where we don't want to set an ERROR health state on transient errors (which cause immediate pages) and would rather use a `WARNING` health state without having to repro all of the logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/16)
<!-- Reviewable:end -->
