### PR TITLE
Update witchcraft-health-api Conjure definition to 1.3.0

### DIFF
--- a/changelog/@unreleased/pr-31.v2.yml
+++ b/changelog/@unreleased/pr-31.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Updates witchcraft-health-api Conjure definition to 1.3.0
+  links:
+  - https://github.com/palantir/witchcraft-go-health/pull/31

--- a/godel/config/conjure-plugin.yml
+++ b/godel/config/conjure-plugin.yml
@@ -2,4 +2,4 @@ version: 1
 projects:
   conjure:
     output-dir: ./conjure
-    ir-locator: https://palantir.bintray.com/releases/com/palantir/witchcraft/api/witchcraft-health-api/1.0.0/witchcraft-health-api-1.0.0.conjure.json
+    ir-locator: https://repo1.maven.org/maven2/com/palantir/witchcraft/api/witchcraft-health-api/1.3.0/witchcraft-health-api-1.3.0.conjure.json


### PR DESCRIPTION
Use IR in maven-central rather than Bintray.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates witchcraft-health-api Conjure definition to 1.3.0
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/31)
<!-- Reviewable:end -->
