### PR TITLE
improvement: Add WithFailingHealthStateValue support to the KeyedErrorHealthCheckSource.

### DIFF
--- a/changelog/@unreleased/pr-33.v2.yml
+++ b/changelog/@unreleased/pr-33.v2.yml
@@ -3,6 +3,6 @@ improvement:
   description: |-
     Adds WithFailingHealthStateValue support to the KeyedErrorHealthCheckSource.
 
-    The KeyedErrorHealthCheckSource would previously only report an ERROR health state by default when the health status was computed. Now the WithFailingHealthStateValue can be used for the KeyedErrorHealthCheckSource which configures the health state used to configure the default health state. This option doesn't affect he logic to downgrade failures to a REPAIRING state.
+    The KeyedErrorHealthCheckSource would previously only report an ERROR health state by default when the health status was computed. Now the WithFailingHealthStateValue can be used for the KeyedErrorHealthCheckSource which configures the health state used when reporting a non-healthy health check result. This option doesn't affect the logic to downgrade failures to a REPAIRING state.
   links:
   - https://github.com/palantir/witchcraft-go-health/pull/33

--- a/changelog/@unreleased/pr-33.v2.yml
+++ b/changelog/@unreleased/pr-33.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Adds WithFailingHealthStateValue support to the KeyedErrorHealthCheckSource.
+
+    The KeyedErrorHealthCheckSource would previously only report an ERROR health state by default when the health status was computed. Now the WithFailingHealthStateValue can be used for the KeyedErrorHealthCheckSource which configures the health state used to configure the default health state. This option doesn't affect he logic to downgrade failures to a REPAIRING state.
+  links:
+  - https://github.com/palantir/witchcraft-go-health/pull/33


### PR DESCRIPTION
## Before this PR
The KeyedErrorHealthCheckSource did not respect the WithFailingHealthStateValue ErrorOption. This option allows a user to override the health state value when the healthcheck goes into an erroring state. Whenever the KeyedErrorHealthCheckSource went into an error state it would always be of state ERROR. 

## After this PR
The KeyedErrorHealthCheckSource will now use the health state value specified in the error options, defaulting to ERROR when it isn't supplied. 
==COMMIT_MSG==
Add WithFailingHealthStateValue support to the KeyedErrorHealthCheckSource.
==COMMIT_MSG==

## Possible downsides?
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/33)
<!-- Reviewable:end -->
