### PR TITLE
Add MustInitializeHealthComponent to HealthReporter interface

### DIFF
--- a/changelog/@unreleased/pr-34.v2.yml
+++ b/changelog/@unreleased/pr-34.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |-
+    Add MustInitializeHealthComponent convenience function to avoid unnecessary error handling
+  links:
+    - https://github.com/palantir/witchcraft-go-health/pull/34

--- a/reporter/healthreporter.go
+++ b/reporter/healthreporter.go
@@ -30,7 +30,6 @@ var _ HealthReporter = &healthReporter{}
 
 type HealthReporter interface {
 	status.HealthCheckSource
-	MustInitializeHealthComponent(name string) HealthComponent
 	InitializeHealthComponent(name string) (HealthComponent, error)
 	GetHealthComponent(name string) (HealthComponent, bool)
 	UnregisterHealthComponent(name string) bool
@@ -53,10 +52,10 @@ func newHealthReporter() *healthReporter {
 	}
 }
 
-// MustInitializeHealthComponent - Same as InitializeHealthComponent, but panics if the component name is
-// non-SLS compliant, or the name is already in use
-func (r *healthReporter) MustInitializeHealthComponent(name string) HealthComponent {
-	healthComponent, err := r.InitializeHealthComponent(name)
+// MustInitializeHealthComponent is a convenience function that calls InitializeHealthComponent on the provided
+// HealthReporter and panics if an error would have occurred
+func MustInitializeHealthComponent(hr HealthReporter, name string) HealthComponent {
+	healthComponent, err := hr.InitializeHealthComponent(name)
 	if err != nil {
 		panic(err)
 	}

--- a/reporter/healthreporter.go
+++ b/reporter/healthreporter.go
@@ -30,6 +30,7 @@ var _ HealthReporter = &healthReporter{}
 
 type HealthReporter interface {
 	status.HealthCheckSource
+	MustInitializeHealthComponent(name string) HealthComponent
 	InitializeHealthComponent(name string) (HealthComponent, error)
 	GetHealthComponent(name string) (HealthComponent, bool)
 	UnregisterHealthComponent(name string) bool
@@ -50,6 +51,16 @@ func newHealthReporter() *healthReporter {
 	return &healthReporter{
 		healthComponents: make(map[health.CheckType]HealthComponent),
 	}
+}
+
+// MustInitializeHealthComponent - Same as InitializeHealthComponent, but panics if the component name is
+// non-SLS compliant, or the name is already in use
+func (r *healthReporter) MustInitializeHealthComponent(name string) HealthComponent {
+	healthComponent, err := r.InitializeHealthComponent(name)
+	if err != nil {
+		panic(err)
+	}
+	return healthComponent
 }
 
 // InitializeHealthComponent - Creates a health component for the given name where the component should be stated as


### PR DESCRIPTION
## Before this PR
The `InitializeHealthComponent` function is often called on startup, with a statically defined component name, in which case the caller knows that it will never return an error.

## After this PR
Adds `MustInitializeHealthComponent` convenience function which panics when an error would have occurred. This makes the calling code cleaner and self-documenting.

==COMMIT_MSG==
Add MustInitializeHealthComponent convenience function to avoid unnecessary error handling
==COMMIT_MSG==

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/34)
<!-- Reviewable:end -->
