### PR TITLE
Improvement: Add the ability to trim keys no longer in use from the keyedErrorHealthCheckSource

### DIFF
--- a/changelog/@unreleased/pr-44.v2.yml
+++ b/changelog/@unreleased/pr-44.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |-
+    Add the ability to trim keys no longer in use from the keyedErrorHealthCheckSource
+  links:
+    - https://github.com/palantir/witchcraft-go-health/pull/44

--- a/changelog/@unreleased/pr-44.v2.yml
+++ b/changelog/@unreleased/pr-44.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
   description: |-
-    Add the ability to trim keys no longer in use from the keyedErrorHealthCheckSource
+    Adds PurgeKeys to window.KeyedErrorSubmitter interface, allowing a caller to remove entries from a keyed window health check.
   links:
     - https://github.com/palantir/witchcraft-go-health/pull/44


### PR DESCRIPTION
- Add the ability to trim keys no longer in use from the keyedErrorHealthCheckSource 
- There are times in which there are stale keys that are in the health check that need to be purged
- We may not know what those keys are, but we do know they keys that we are still tracking. 
- This gives us the ability to ensure those keys are only the ones being tracked

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/44)
<!-- Reviewable:end -->
