### PR TITLE
fix: combinedHealthCheckSource skips nil members to avoid panics

### DIFF
--- a/changelog/@unreleased/pr-45.v2.yml
+++ b/changelog/@unreleased/pr-45.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: CombinedHealthCheckSource skips nil members to avoid panics
+  links:
+  - https://github.com/palantir/witchcraft-go-health/pull/45

--- a/status/status.go
+++ b/status/status.go
@@ -59,6 +59,9 @@ func (c *combinedHealthCheckSource) HealthStatus(ctx context.Context) health.Hea
 		Checks: map[health.CheckType]health.HealthCheckResult{},
 	}
 	for _, healthCheckSource := range c.healthCheckSources {
+		if healthCheckSource == nil {
+			continue
+		}
 		for k, v := range healthCheckSource.HealthStatus(ctx).Checks {
 			result.Checks[k] = v
 		}

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -55,7 +55,7 @@ func TestCombinedHealthCheckSource(t *testing.T) {
 			},
 		},
 	}
-	combined := NewCombinedHealthCheckSource(sourceA, sourceB)
+	combined := NewCombinedHealthCheckSource(sourceA, sourceB, nil)
 	actual := combined.HealthStatus(context.Background())
 	assert.Equal(t, health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/45)
<!-- Reviewable:end -->
