### PR TITLE
Don't report the last heartbeat timestamp unless the check is unhealthy

### DIFF
--- a/changelog/@unreleased/pr-51.v2.yml
+++ b/changelog/@unreleased/pr-51.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Don't report the last heartbeat timestamp unless the check is unhealthy
+  links:
+  - https://github.com/palantir/witchcraft-go-health/pull/51

--- a/sources/heartbeat/source.go
+++ b/sources/heartbeat/source.go
@@ -144,7 +144,7 @@ func (h *HealthCheckSource) HealthStatus(_ context.Context) health.HealthStatus 
 	}
 
 	params := map[string]interface{}{
-		"heartbeatTimeout":  h.heartbeatTimeout.String(),
+		"heartbeatTimeout": h.heartbeatTimeout.String(),
 	}
 	if curTime.Sub(h.lastHeartbeatTime) < h.heartbeatTimeout {
 		return health.HealthStatus{

--- a/sources/heartbeat/source.go
+++ b/sources/heartbeat/source.go
@@ -24,6 +24,10 @@ import (
 	"github.com/palantir/witchcraft-go-health/status"
 )
 
+const (
+	lastHeartbeatParam = "lastHeartbeatTime"
+)
+
 // HealthCheckSource is a thread-safe HealthCheckSource based on heartbeats.
 // This is used to monitor if some process is continuously running by receiving heartbeats (pings) with timeouts.
 // Heartbeats are submitted manually using the Heartbeat or the HeartbeatIfSuccess functions.
@@ -140,7 +144,6 @@ func (h *HealthCheckSource) HealthStatus(_ context.Context) health.HealthStatus 
 	}
 
 	params := map[string]interface{}{
-		"lastHeartbeatTime": h.lastHeartbeatTime.String(),
 		"heartbeatTimeout":  h.heartbeatTimeout.String(),
 	}
 	if curTime.Sub(h.lastHeartbeatTime) < h.heartbeatTimeout {
@@ -156,6 +159,7 @@ func (h *HealthCheckSource) HealthStatus(_ context.Context) health.HealthStatus 
 	}
 
 	message := "Last heartbeat was too long ago"
+	params[lastHeartbeatParam] = h.lastHeartbeatTime.String()
 	return health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{
 			h.checkType: {

--- a/sources/heartbeat/source_test.go
+++ b/sources/heartbeat/source_test.go
@@ -58,6 +58,7 @@ func TestHealthCheckSource_WithHeartbeats_Healthy(t *testing.T) {
 	check, hasCheck := status.Checks[testCheckType]
 	require.True(t, hasCheck)
 	assert.Equal(t, health.HealthState_HEALTHY, check.State.Value())
+	assert.NotContains(t, check.Params, lastHeartbeatParam)
 }
 
 func TestHealthCheckSource_WithHeartbeats_Error(t *testing.T) {
@@ -70,6 +71,7 @@ func TestHealthCheckSource_WithHeartbeats_Error(t *testing.T) {
 	check, hasCheck := status.Checks[testCheckType]
 	require.True(t, hasCheck)
 	assert.Equal(t, health.HealthState_ERROR, check.State.Value())
+	assert.Contains(t, check.Params, lastHeartbeatParam)
 }
 
 func TestHealthCheckSource_WithHeartbeats_HealthyThenErrorThenHealthy(t *testing.T) {


### PR DESCRIPTION
## Before this PR
Internal services using this check were being rate-limited by the health reporting pipeline because the check params were changing too frequently.

## After this PR
Mimic the approach we take with other healthchecks, and omit frequently changing params when the check is healthy. The time of last heartbeat is not particularly important as long as it is within the allowed range. We can continue to include it when the check is failing for additional clarity when debugging.

==COMMIT_MSG==
Don't report the last heartbeat timestamp unless the check is unhealthy
==COMMIT_MSG==

## Possible downsides?
 - Slightly reduced visibility into the state of the check

==MERGE_WHEN_READY==

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/51)
<!-- Reviewable:end -->
