### PR TITLE
fix: Remove the last heartbeat timestamp from heartbeat params

### DIFF
--- a/changelog/@unreleased/pr-62.v2.yml
+++ b/changelog/@unreleased/pr-62.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: |-
+    Exclude the last heartbeat timestamp from heartbeat params.
+  links:
+    - https://github.com/palantir/witchcraft-go-health/pull/62

--- a/changelog/@unreleased/pr-62.v2.yml
+++ b/changelog/@unreleased/pr-62.v2.yml
@@ -1,6 +1,8 @@
 type: fix
 fix:
   description: |-
-    Exclude the last heartbeat timestamp from heartbeat params.
+    Remove the last heartbeat timestamp from heartbeat params. The last
+    heartbeat timestamp is inferable from when the health check switches from
+    a HEALTHY to WARN/ERROR state and the configured heartbeatTimeout.
   links:
     - https://github.com/palantir/witchcraft-go-health/pull/62

--- a/sources/heartbeat/source.go
+++ b/sources/heartbeat/source.go
@@ -24,10 +24,6 @@ import (
 	"github.com/palantir/witchcraft-go-health/status"
 )
 
-const (
-	lastHeartbeatParam = "lastHeartbeatTime"
-)
-
 // HealthCheckSource is a thread-safe HealthCheckSource based on heartbeats.
 // This is used to monitor if some process is continuously running by receiving heartbeats (pings) with timeouts.
 // Heartbeats are submitted manually using the Heartbeat or the HeartbeatIfSuccess functions.

--- a/sources/heartbeat/source.go
+++ b/sources/heartbeat/source.go
@@ -119,7 +119,10 @@ func (h *HealthCheckSource) HealthStatus(ctx context.Context) health.HealthStatu
 		}
 		if curTime.Sub(h.sourceStartupTime) < h.startupTimeout {
 			message := "Waiting for initial heartbeat"
-			svc1log.FromContext(ctx).Debug(message, svc1log.SafeParams(params))
+			svc1log.FromContext(ctx).Debug(
+				message,
+				svc1log.SafeParam("healthCheckType", h.checkType),
+				svc1log.SafeParams(params))
 			return health.HealthStatus{
 				Checks: map[health.CheckType]health.HealthCheckResult{
 					h.checkType: {
@@ -132,7 +135,10 @@ func (h *HealthCheckSource) HealthStatus(ctx context.Context) health.HealthStatu
 		}
 
 		message := "No heartbeats since startup"
-		svc1log.FromContext(ctx).Error(message, svc1log.SafeParams(params))
+		svc1log.FromContext(ctx).Error(
+			message,
+			svc1log.SafeParam("healthCheckType", h.checkType),
+			svc1log.SafeParams(params))
 		return health.HealthStatus{
 			Checks: map[health.CheckType]health.HealthCheckResult{
 				h.checkType: {
@@ -160,7 +166,10 @@ func (h *HealthCheckSource) HealthStatus(ctx context.Context) health.HealthStatu
 
 	message := "Last heartbeat was too long ago"
 	params[lastHeartbeatParam] = h.lastHeartbeatTime.String()
-	svc1log.FromContext(ctx).Error(message, svc1log.SafeParams(params))
+	svc1log.FromContext(ctx).Error(
+		message,
+		svc1log.SafeParam("healthCheckType", h.checkType),
+		svc1log.SafeParams(params))
 	return health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{
 			h.checkType: {

--- a/sources/heartbeat/source_test.go
+++ b/sources/heartbeat/source_test.go
@@ -71,7 +71,7 @@ func TestHealthCheckSource_WithHeartbeats_Error(t *testing.T) {
 	check, hasCheck := status.Checks[testCheckType]
 	require.True(t, hasCheck)
 	assert.Equal(t, health.HealthState_ERROR, check.State.Value())
-	assert.Contains(t, check.Params, lastHeartbeatParam)
+	assert.NotContains(t, check.Params, lastHeartbeatParam)
 }
 
 func TestHealthCheckSource_WithHeartbeats_HealthyThenErrorThenHealthy(t *testing.T) {

--- a/sources/heartbeat/source_test.go
+++ b/sources/heartbeat/source_test.go
@@ -58,7 +58,7 @@ func TestHealthCheckSource_WithHeartbeats_Healthy(t *testing.T) {
 	check, hasCheck := status.Checks[testCheckType]
 	require.True(t, hasCheck)
 	assert.Equal(t, health.HealthState_HEALTHY, check.State.Value())
-	assert.NotContains(t, check.Params, lastHeartbeatParam)
+	assert.Nil(t, check.Params)
 }
 
 func TestHealthCheckSource_WithHeartbeats_Error(t *testing.T) {
@@ -71,7 +71,7 @@ func TestHealthCheckSource_WithHeartbeats_Error(t *testing.T) {
 	check, hasCheck := status.Checks[testCheckType]
 	require.True(t, hasCheck)
 	assert.Equal(t, health.HealthState_ERROR, check.State.Value())
-	assert.NotContains(t, check.Params, lastHeartbeatParam)
+	assert.Nil(t, check.Params)
 }
 
 func TestHealthCheckSource_WithHeartbeats_HealthyThenErrorThenHealthy(t *testing.T) {


### PR DESCRIPTION
## Before this PR
Including the last heartbeat timestamp in the health payload can cause
the health check to trigger too many health updates within internal
infrastructure.

## After this PR
~Delegate providing the last timestamp to a log message.~ 

The last heartbeat timestamp is inferable from when the health check status switches from a healthy to a warning/error state. Therefore we remove the last heartbeat timestamp from the params entirely. 
==COMMIT_MSG==
Exclude the last heartbeat timestamp from heartbeat params
==COMMIT_MSG==

## Possible downsides?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/62)
<!-- Reviewable:end -->
