### PR TITLE
improvement: Add HealthyIfAtLeastOneSuccess window mode for 'heartbeating' error reporter

### DIFF
--- a/changelog/@unreleased/pr-67.v2.yml
+++ b/changelog/@unreleased/pr-67.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add HealthyIfAtLeastOneSuccess window mode for 'heartbeating' error
+    reporter
+  links:
+  - https://github.com/palantir/witchcraft-go-health/pull/67

--- a/sources/utils.go
+++ b/sources/utils.go
@@ -39,6 +39,16 @@ func RepairingHealthCheckResult(checkType health.CheckType, message string, para
 	}
 }
 
+// WarningHealthCheckResult returns a warning health check result with type checkType and message message.
+func WarningHealthCheckResult(checkType health.CheckType, message string, params map[string]interface{}) health.HealthCheckResult {
+	return health.HealthCheckResult{
+		Type:    checkType,
+		State:   health.New_HealthState(health.HealthState_WARNING),
+		Message: &message,
+		Params:  params,
+	}
+}
+
 // HealthyHealthCheckResult returns healthy health check result with type checkType.
 func HealthyHealthCheckResult(checkType health.CheckType) health.HealthCheckResult {
 	return health.HealthCheckResult{

--- a/sources/window/error_options.go
+++ b/sources/window/error_options.go
@@ -36,6 +36,10 @@ const (
 	// check source return unhealthy if the most recent submission is an error.
 	// Returns healthy if there no submissions in the window.
 	HealthyIfNoRecentErrors ErrorMode = "HealthyIfNoRecentErrors"
+	// HealthyIfAtLeastOneSuccess makes the error submitter based health
+	// check source return unhealthy if there has not been a success in the window.
+	// If there are errors, the most recent is reported.
+	HealthyIfAtLeastOneSuccess ErrorMode = "HealthyIfAtLeastOneSuccess"
 )
 
 // ErrorOption is an option for an error submitter based window health check source.


### PR DESCRIPTION
## Before this PR
All the available error modes return success when there have been no submissions within the window.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add HealthyIfAtLeastOneSuccess window mode for 'heartbeating' error reporter
==COMMIT_MSG==

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/67)
<!-- Reviewable:end -->
