### PR TITLE
fix: options not passsed to underlying health check source

### DIFF
--- a/changelog/@unreleased/pr-71.v2.yml
+++ b/changelog/@unreleased/pr-71.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: |-
+    Fix MustNewHealthCheckSource to pass provided options to NewHealthCheckSource
+  links:
+    - https://github.com/palantir/witchcraft-go-health/pull/71

--- a/sources/heartbeat/source.go
+++ b/sources/heartbeat/source.go
@@ -69,7 +69,7 @@ func NewHealthCheckSourceWithStartupGracePeriod(checkType health.CheckType, hear
 // Panics if inputs are invalid.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
 func MustNewHealthCheckSource(checkType health.CheckType, heartbeatTimeout time.Duration, options ...Option) *HealthCheckSource {
-	healthCheckSource, err := NewHealthCheckSource(checkType, heartbeatTimeout)
+	healthCheckSource, err := NewHealthCheckSource(checkType, heartbeatTimeout, options...)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Before this PR
When using `MustNewHealthCheckSource` with options, the provided options were not passed to the underlying `NewHealthCheckSource`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix `MustNewHealthCheckSource` to pass provided options to `NewHealthCheckSource`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/71)
<!-- Reviewable:end -->
