### PR TITLE
Fix HealthyIfNoRecentErrors behavior

### DIFF
--- a/changelog/@unreleased/pr-187.v2.yml
+++ b/changelog/@unreleased/pr-187.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix HealthyIfNoRecentErrors behavior to return healthy when there are no submissions within the evaluation window
+  links:
+  - https://github.com/palantir/witchcraft-go-health/pull/187

--- a/sources/window/error_source.go
+++ b/sources/window/error_source.go
@@ -149,7 +149,7 @@ func (e *errorHealthCheckSource) HealthStatus(ctx context.Context) health.Health
 			healthCheckResult = sources.HealthyHealthCheckResult(e.checkType)
 		}
 	case HealthyIfNoRecentErrors:
-		if e.lastErrorTime.After(e.lastSuccessTime) {
+		if e.hasErrorInWindow() && e.lastErrorTime.After(e.lastSuccessTime) {
 			healthCheckResult = e.getFailureResult(e.lastError)
 		} else {
 			healthCheckResult = sources.HealthyHealthCheckResult(e.checkType)


### PR DESCRIPTION
## Before this PR
The doc for `HealthyIfNoRecentErrors` did not describe the actual behavior.

This comment implies that if I have a 5 minute window, and my last submission was an error 10 minutes ago, the check should return healthy.
https://github.com/palantir/witchcraft-go-health/blob/f703a800771ac7de50ee8687b12aa987f9de1d82/sources/window/error_options.go#L37

The actual code will still return unhealthy in that case, since it only checks whether there has been a success since the last error, without verifying that the last error is within the window
https://github.com/palantir/witchcraft-go-health/blob/f703a800771ac7de50ee8687b12aa987f9de1d82/sources/window/error_source.go#L152
 

## After this PR
The behavior of `HealthyIfNoRecentErrors` now reflects the godoc. Additionally, tests have been added for all evaluation methods to cover the behavior of each when there are submissions but they are all older than the evaluation window (all other evaluation methods were implemented correctly, just not explicitly tested).

==COMMIT_MSG==
Fix HealthyIfNoRecentErrors behavior
==COMMIT_MSG==

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/187)
<!-- Reviewable:end -->
