### PR TITLE
improvement: Add a KeyedErrorSourceAccumulator interface and implementation 

### DIFF
--- a/changelog/@unreleased/pr-297.v2.yml
+++ b/changelog/@unreleased/pr-297.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add a KeyedErrorSourceAccumulator interface and implementation
+  links:
+  - https://github.com/palantir/witchcraft-go-health/pull/297

--- a/sources/window/keyed_error_source_accumulator.go
+++ b/sources/window/keyed_error_source_accumulator.go
@@ -1,0 +1,56 @@
+package window
+
+import (
+	"context"
+	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-health/status"
+	"sync"
+)
+
+// KeyedErrorSourceAccumulator extends the KeyedErrorHealthCheckSource interface
+// It includes an additional method AddHealthCheckSource which allows health sources to be added into the base health sources
+// These sources are queried in conjunction with the given KeyedErrorHealthCheckSource
+// This can be useful if you are working in legacy code bases and are in the process of converting health check, but need to add existing checks into a KeyedErrorHealthCheckSource
+type KeyedErrorSourceAccumulator interface {
+	AddHealthCheckSource(healthCheckSource status.HealthCheckSource)
+	KeyedErrorHealthCheckSource
+}
+
+type defaultKeyedErrorSourceAccumulator struct {
+	mutex                       sync.Mutex
+	keyedErrorHealthCheckSource KeyedErrorHealthCheckSource
+	allSources                  []status.HealthCheckSource
+}
+
+// NewDefaultKeyedErrorSourceAccumulator is the default implementation of KeyedErrorSourceAccumulator
+func NewDefaultKeyedErrorSourceAccumulator(keyedErrorHealthCheckSource KeyedErrorHealthCheckSource) KeyedErrorSourceAccumulator {
+	return &defaultKeyedErrorSourceAccumulator{
+		keyedErrorHealthCheckSource: keyedErrorHealthCheckSource,
+		allSources:                  []status.HealthCheckSource{keyedErrorHealthCheckSource},
+	}
+}
+
+func (n *defaultKeyedErrorSourceAccumulator) AddHealthCheckSource(healthCheckSource status.HealthCheckSource) {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+	n.allSources = append(n.allSources, healthCheckSource)
+}
+
+func (n *defaultKeyedErrorSourceAccumulator) Submit(key string, err error) {
+	n.keyedErrorHealthCheckSource.Submit(key, err)
+}
+
+func (n *defaultKeyedErrorSourceAccumulator) HealthStatus(ctx context.Context) health.HealthStatus {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+	result := health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{},
+	}
+	for _, healthCheckSource := range n.allSources {
+		for k, v := range healthCheckSource.HealthStatus(ctx).Checks {
+			result.Checks[k] = v
+		}
+	}
+	return result
+
+}

--- a/sources/window/keyed_error_source_accumulator.go
+++ b/sources/window/keyed_error_source_accumulator.go
@@ -1,10 +1,25 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package window
 
 import (
 	"context"
+	"sync"
+
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-health/status"
-	"sync"
 )
 
 // KeyedErrorSourceAccumulator extends the KeyedErrorHealthCheckSource interface

--- a/sources/window/keyed_error_source_accumulator_test.go
+++ b/sources/window/keyed_error_source_accumulator_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package window
+
+import (
+	"context"
+	"errors"
+	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestKeyedErrorSourceAccumulatorCanError(t *testing.T) {
+	keyedErrorSourceAccumulator := NewDefaultKeyedErrorSourceAccumulator(MustNewKeyedErrorHealthCheckSource("check", UnhealthyIfAtLeastOneError))
+	keyedErrorSourceAccumulator.Submit("key", errors.New("uhoh"))
+	str := ""
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"check": {
+				Type:    "check",
+				State:   health.New_HealthState(health.HealthState_ERROR),
+				Message: &str,
+				Params: map[string]interface{}{
+					"key": "uhoh",
+				},
+			},
+		},
+	}, keyedErrorSourceAccumulator.HealthStatus(context.Background()))
+}
+
+func TestKeyedErrorSourceAccumulatorCanAdd(t *testing.T) {
+	keyedErrorSourceAccumulator := NewDefaultKeyedErrorSourceAccumulator(MustNewKeyedErrorHealthCheckSource("check", UnhealthyIfAtLeastOneError))
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"check": {
+				Type:  "check",
+				State: health.New_HealthState(health.HealthState_HEALTHY),
+			},
+		},
+	}, keyedErrorSourceAccumulator.HealthStatus(context.Background()))
+	anotherCheck := MustNewKeyedErrorHealthCheckSource("check2", UnhealthyIfAtLeastOneError)
+	keyedErrorSourceAccumulator.AddHealthCheckSource(anotherCheck)
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"check": {
+				Type:  "check",
+				State: health.New_HealthState(health.HealthState_HEALTHY),
+			},
+			"check2": {
+				Type:  "check2",
+				State: health.New_HealthState(health.HealthState_HEALTHY),
+			},
+		},
+	}, keyedErrorSourceAccumulator.HealthStatus(context.Background()))
+	anotherCheck.Submit("key", errors.New("uhoh"))
+	str := ""
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"check": {
+				Type:  "check",
+				State: health.New_HealthState(health.HealthState_HEALTHY),
+			},
+			"check2": {
+				Type:    "check2",
+				State:   health.New_HealthState(health.HealthState_ERROR),
+				Message: &str,
+				Params: map[string]interface{}{
+					"key": "uhoh",
+				},
+			},
+		},
+	}, keyedErrorSourceAccumulator.HealthStatus(context.Background()))
+}

--- a/sources/window/keyed_error_source_accumulator_test.go
+++ b/sources/window/keyed_error_source_accumulator_test.go
@@ -17,9 +17,10 @@ package window
 import (
 	"context"
 	"errors"
+	"testing"
+
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestKeyedErrorSourceAccumulatorCanError(t *testing.T) {


### PR DESCRIPTION
- Add a KeyedErrorSourceAccumulator interface and implementation
- // KeyedErrorSourceAccumulator extends the KeyedErrorHealthCheckSource interface
// It includes an additional method AddHealthCheckSource which allows health sources to be added into the base health sources
// These sources are queried in conjunction with the given KeyedErrorHealthCheckSource
// This can be useful if you are working in legacy code bases

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/297)
<!-- Reviewable:end -->
