### PR TITLE
improvement: add HealthBasedReadinessSource adapter

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -113,25 +113,23 @@ func HealthStatusCode(metadata health.HealthStatus) int {
 // health check sources. The readiness status is OK if all health check sources report a healthy
 // state (HEALTHY, DEFERRING, or WARNING). Otherwise, it returns the status code corresponding to
 // the first non-OK health state encountered.
-func HealthBasedReadinessSource(healthSources ...HealthCheckSource) Source {
+func HealthBasedReadinessSource(healthCheckSources refreshable.Refreshable[[]HealthCheckSource]) Source {
 	return &healthBasedReadinessSource{
-		healthSources: healthSources,
+		healthSource: NewCombinedHealthCheckSourceWithRefresh(healthCheckSources),
 	}
 }
 
 type healthBasedReadinessSource struct {
-	healthSources []HealthCheckSource
+	healthSource HealthCheckSource
 }
 
-func (h *healthBasedReadinessSource) Status() (respStatus int, metadata interface{}) {
+func (h *healthBasedReadinessSource) Status() (int, interface{}) {
 	ctx := context.Background()
-	for _, healthSource := range h.healthSources {
-		healthStatus := healthSource.HealthStatus(ctx)
-		for _, check := range healthStatus.Checks {
-			state := check.State.Value()
-			if !slices.Contains(readyHealthStates, state) {
-				return HealthStateStatusCode(state), check
-			}
+	healthStatus := h.healthSource.HealthStatus(ctx)
+	for _, check := range healthStatus.Checks {
+		state := check.State.Value()
+		if !slices.Contains(readyHealthStates, state) {
+			return HealthStateStatusCode(state), check
 		}
 	}
 

--- a/status/status.go
+++ b/status/status.go
@@ -17,6 +17,7 @@ package status
 import (
 	"context"
 	"net/http"
+	"slices"
 
 	"github.com/palantir/pkg/refreshable/v2"
 	"github.com/palantir/witchcraft-go-health/v2/conjure/witchcraft/api/health"
@@ -31,6 +32,13 @@ var (
 		health.HealthState_WARNING:   521,
 		health.HealthState_ERROR:     522,
 		health.HealthState_TERMINAL:  523,
+	}
+
+	// readyHealthStates defines the health states that indicate a service is ready
+	readyHealthStates = []health.HealthState_Value{
+		health.HealthState_HEALTHY,
+		health.HealthState_DEFERRING,
+		health.HealthState_WARNING,
 	}
 )
 
@@ -99,4 +107,34 @@ func HealthStatusCode(metadata health.HealthStatus) int {
 		}
 	}
 	return worst
+}
+
+// HealthBasedReadinessSource creates a Source that determines readiness based on the provided
+// health check sources. The readiness status is OK if all health check sources report a healthy
+// state (HEALTHY, DEFERRING, or WARNING). Otherwise, it returns the status code corresponding to
+// the first non-OK health state encountered.
+func HealthBasedReadinessSource(healthSources ...HealthCheckSource) Source {
+	return &healthBasedReadinessSource{
+		healthSources: healthSources,
+	}
+}
+
+type healthBasedReadinessSource struct {
+	healthSources []HealthCheckSource
+}
+
+func (h *healthBasedReadinessSource) Status() (respStatus int, metadata interface{}) {
+	ctx := context.Background()
+	for _, healthSource := range h.healthSources {
+		healthStatus := healthSource.HealthStatus(ctx)
+		for _, check := range healthStatus.Checks {
+			state := check.State.Value()
+			if !slices.Contains(readyHealthStates, state) {
+				return HealthStateStatusCode(state), check
+			}
+		}
+	}
+
+	// All checks passed
+	return http.StatusOK, nil
 }

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -273,7 +273,7 @@ func TestHealthBasedReadinessSource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			source := HealthBasedReadinessSource(tt.healthSources...)
+			source := HealthBasedReadinessSource(refreshable.New(tt.healthSources))
 			status, metadata := source.Status()
 			assert.Equal(t, tt.expectedStatus, status)
 			if tt.expectMetadata {

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -16,6 +16,7 @@ package status
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/palantir/pkg/refreshable/v2"
@@ -114,4 +115,172 @@ func TestCombinedHealthCheckSourceWithRefreshable(t *testing.T) {
 			},
 		},
 	}, actual)
+}
+
+func TestHealthBasedReadinessSource(t *testing.T) {
+	tests := []struct {
+		name           string
+		healthSources  []HealthCheckSource
+		expectedStatus int
+		expectMetadata bool
+	}{
+		{
+			name: "all checks healthy, deferring or warning returns OK",
+			healthSources: []HealthCheckSource{
+				&testHealthCheckSource{
+					healthStatus: health.HealthStatus{
+						Checks: map[health.CheckType]health.HealthCheckResult{
+							"check1": {
+								State: health.New_HealthState(health.HealthState_HEALTHY),
+							},
+						},
+					},
+				},
+				&testHealthCheckSource{
+					healthStatus: health.HealthStatus{
+						Checks: map[health.CheckType]health.HealthCheckResult{
+							"check2": {
+								State: health.New_HealthState(health.HealthState_DEFERRING),
+							},
+						},
+					},
+				},
+				&testHealthCheckSource{
+					healthStatus: health.HealthStatus{
+						Checks: map[health.CheckType]health.HealthCheckResult{
+							"check3": {
+								State: health.New_HealthState(health.HealthState_WARNING),
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expectMetadata: false,
+		},
+		{
+			name: "mixed ready states returns OK",
+			healthSources: []HealthCheckSource{
+				&testHealthCheckSource{
+					healthStatus: health.HealthStatus{
+						Checks: map[health.CheckType]health.HealthCheckResult{
+							"check1": {
+								State: health.New_HealthState(health.HealthState_HEALTHY),
+							},
+							"check2": {
+								State: health.New_HealthState(health.HealthState_DEFERRING),
+							},
+							"check3": {
+								State: health.New_HealthState(health.HealthState_WARNING),
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expectMetadata: false,
+		},
+		{
+			name: "error state returns error status code",
+			healthSources: []HealthCheckSource{
+				&testHealthCheckSource{
+					healthStatus: health.HealthStatus{
+						Checks: map[health.CheckType]health.HealthCheckResult{
+							"check1": {
+								State: health.New_HealthState(health.HealthState_ERROR),
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: 522,
+			expectMetadata: true,
+		},
+		{
+			name: "suspended state returns suspended status code",
+			healthSources: []HealthCheckSource{
+				&testHealthCheckSource{
+					healthStatus: health.HealthStatus{
+						Checks: map[health.CheckType]health.HealthCheckResult{
+							"check1": {
+								State: health.New_HealthState(health.HealthState_SUSPENDED),
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: 519,
+			expectMetadata: true,
+		},
+		{
+			name: "repairing state returns repairing status code",
+			healthSources: []HealthCheckSource{
+				&testHealthCheckSource{
+					healthStatus: health.HealthStatus{
+						Checks: map[health.CheckType]health.HealthCheckResult{
+							"check1": {
+								State: health.New_HealthState(health.HealthState_REPAIRING),
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: 520,
+			expectMetadata: true,
+		},
+		{
+			name: "terminal state returns terminal status code",
+			healthSources: []HealthCheckSource{
+				&testHealthCheckSource{
+					healthStatus: health.HealthStatus{
+						Checks: map[health.CheckType]health.HealthCheckResult{
+							"check1": {
+								State: health.New_HealthState(health.HealthState_TERMINAL),
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: 523,
+			expectMetadata: true,
+		},
+		{
+			name: "multiple sources with one non-ready returns error",
+			healthSources: []HealthCheckSource{
+				&testHealthCheckSource{
+					healthStatus: health.HealthStatus{
+						Checks: map[health.CheckType]health.HealthCheckResult{
+							"check1": {
+								State: health.New_HealthState(health.HealthState_HEALTHY),
+							},
+						},
+					},
+				},
+				&testHealthCheckSource{
+					healthStatus: health.HealthStatus{
+						Checks: map[health.CheckType]health.HealthCheckResult{
+							"check2": {
+								State: health.New_HealthState(health.HealthState_SUSPENDED),
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: 519,
+			expectMetadata: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := HealthBasedReadinessSource(tt.healthSources...)
+			status, metadata := source.Status()
+			assert.Equal(t, tt.expectedStatus, status)
+			if tt.expectMetadata {
+				assert.NotNil(t, metadata)
+			} else {
+				assert.Nil(t, metadata)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Adding an adapter for health check sources to convert into a `Source` type to support health as readiness 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-health/342)
<!-- Reviewable:end -->
