### PR TITLE
improvement: Add more flexibility to the KeyedErrorSourceAccumulator to allow for rooting it under a delegating health check if needed

### DIFF
--- a/sources/utils.go
+++ b/sources/utils.go
@@ -15,8 +15,11 @@
 package sources
 
 import (
+	"context"
+
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-health/v2/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-health/v2/status"
 )
 
 // UnhealthyHealthCheckResult returns an unhealthy health check result with type checkType and message message.
@@ -61,4 +64,19 @@ func HealthyHealthCheckResult(checkType health.CheckType) health.HealthCheckResu
 func SafeParamsFromError(err error) map[string]any {
 	safeParams, _ := werror.ParamsFromError(err)
 	return safeParams
+}
+
+type staticHealthCheckSource struct {
+	healthStatus health.HealthStatus
+}
+
+func StaticHealthCheckSource(healthStatus health.HealthStatus) status.HealthCheckSource {
+	return &staticHealthCheckSource{
+		healthStatus: healthStatus,
+	}
+}
+
+// HealthStatus implements [status.HealthCheckSource].
+func (s *staticHealthCheckSource) HealthStatus(ctx context.Context) health.HealthStatus {
+	return s.healthStatus
 }

--- a/sources/window/keyed_error_source_accumulator.go
+++ b/sources/window/keyed_error_source_accumulator.go
@@ -31,6 +31,7 @@ import (
 // This can be useful if you are working in legacy code bases and are in the process of converting health check, but need to add existing checks into a KeyedErrorHealthCheckSource
 type KeyedErrorSourceAccumulator interface {
 	AddHealthCheckSource(healthCheckSource status.HealthCheckSource)
+	RootUnderTree(healthCheckSource status.HealthCheckSource)
 	KeyedErrorHealthCheckSource
 }
 
@@ -52,9 +53,7 @@ func NewDefaultKeyedErrorSourceAccumulator(keyedErrorHealthCheckSource KeyedErro
 		allSources:                  []status.HealthCheckSource{keyedErrorHealthCheckSource},
 	}
 	staticParent := sources.StaticHealthCheckSource(health.HealthStatus{
-		Checks: map[health.CheckType]health.HealthCheckResult{
-			"ALWAYS_HEALTHY": sources.HealthyHealthCheckResult("ALWAYS_HEALTHY"),
-		},
+		Checks: map[health.CheckType]health.HealthCheckResult{},
 	})
 	defaultKeyedErrorSourceAccumulatorParent := &defaultKeyedErrorSourceAccumulatorParent{
 		defaultKeyedErrorSourceAccumulator: defaultKeyedErrorSourceAccumulator,

--- a/sources/window/keyed_error_source_accumulator.go
+++ b/sources/window/keyed_error_source_accumulator.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 
 	"github.com/palantir/witchcraft-go-health/v2/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-health/v2/sources"
+	"github.com/palantir/witchcraft-go-health/v2/sources/tree"
 	"github.com/palantir/witchcraft-go-health/v2/status"
 )
 
@@ -33,32 +35,59 @@ type KeyedErrorSourceAccumulator interface {
 }
 
 type defaultKeyedErrorSourceAccumulator struct {
-	mutex                       sync.Mutex
 	keyedErrorHealthCheckSource KeyedErrorHealthCheckSource
 	allSources                  []status.HealthCheckSource
 }
 
+type defaultKeyedErrorSourceAccumulatorParent struct {
+	mutex                              sync.Mutex
+	defaultKeyedErrorSourceAccumulator *defaultKeyedErrorSourceAccumulator
+	rootedHealthCheck                  status.HealthCheckSource
+}
+
 // NewDefaultKeyedErrorSourceAccumulator is the default implementation of KeyedErrorSourceAccumulator
 func NewDefaultKeyedErrorSourceAccumulator(keyedErrorHealthCheckSource KeyedErrorHealthCheckSource) KeyedErrorSourceAccumulator {
-	return &defaultKeyedErrorSourceAccumulator{
+	defaultKeyedErrorSourceAccumulator := &defaultKeyedErrorSourceAccumulator{
 		keyedErrorHealthCheckSource: keyedErrorHealthCheckSource,
 		allSources:                  []status.HealthCheckSource{keyedErrorHealthCheckSource},
 	}
+	staticParent := sources.StaticHealthCheckSource(health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"ALWAYS_HEALTHY": sources.HealthyHealthCheckResult("ALWAYS_HEALTHY"),
+		},
+	})
+	defaultKeyedErrorSourceAccumulatorParent := &defaultKeyedErrorSourceAccumulatorParent{
+		defaultKeyedErrorSourceAccumulator: defaultKeyedErrorSourceAccumulator,
+	}
+	defaultKeyedErrorSourceAccumulatorParent.RootUnderTree(staticParent)
+	return defaultKeyedErrorSourceAccumulatorParent
 }
 
-func (n *defaultKeyedErrorSourceAccumulator) AddHealthCheckSource(healthCheckSource status.HealthCheckSource) {
+func (n *defaultKeyedErrorSourceAccumulatorParent) AddHealthCheckSource(healthCheckSource status.HealthCheckSource) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
-	n.allSources = append(n.allSources, healthCheckSource)
+	n.defaultKeyedErrorSourceAccumulator.allSources = append(n.defaultKeyedErrorSourceAccumulator.allSources, healthCheckSource)
 }
 
-func (n *defaultKeyedErrorSourceAccumulator) Submit(ctx context.Context, key string, err error) {
-	n.keyedErrorHealthCheckSource.Submit(ctx, key, err)
+func (n *defaultKeyedErrorSourceAccumulatorParent) RootUnderTree(healthCheckSource status.HealthCheckSource) {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+	n.rootedHealthCheck = tree.NewHealthCheckSourceTree(healthCheckSource, []status.HealthCheckSource{n.defaultKeyedErrorSourceAccumulator})
+}
+
+func (n *defaultKeyedErrorSourceAccumulatorParent) Submit(ctx context.Context, key string, err error) {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+	n.defaultKeyedErrorSourceAccumulator.keyedErrorHealthCheckSource.Submit(ctx, key, err)
+}
+
+func (n *defaultKeyedErrorSourceAccumulatorParent) HealthStatus(ctx context.Context) health.HealthStatus {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+	return n.rootedHealthCheck.HealthStatus(ctx)
 }
 
 func (n *defaultKeyedErrorSourceAccumulator) HealthStatus(ctx context.Context) health.HealthStatus {
-	n.mutex.Lock()
-	defer n.mutex.Unlock()
 	result := health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{},
 	}

--- a/sources/window/keyed_error_source_accumulator_test.go
+++ b/sources/window/keyed_error_source_accumulator_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/palantir/witchcraft-go-health/v2/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-health/v2/sources"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -81,6 +82,65 @@ func TestKeyedErrorSourceAccumulatorCanAdd(t *testing.T) {
 					"key": "uhoh",
 				},
 			},
+		},
+	}, keyedErrorSourceAccumulator.HealthStatus(context.Background()))
+}
+
+func TestKeyedErrorSourceAccumulatorRootUnderTreeMergesHealthyParentChecks(t *testing.T) {
+	keyedErrorSourceAccumulator := NewDefaultKeyedErrorSourceAccumulator(MustNewKeyedErrorHealthCheckSource("check", UnhealthyIfAtLeastOneError))
+	keyedErrorSourceAccumulator.RootUnderTree(sources.StaticHealthCheckSource(health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"PARENT": sources.HealthyHealthCheckResult("PARENT"),
+		},
+	}))
+	keyedErrorSourceAccumulator.Submit(context.Background(), "key", errors.New("uhoh"))
+	str := ""
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"PARENT": sources.HealthyHealthCheckResult("PARENT"),
+			"check": {
+				Type:    "check",
+				State:   health.New_HealthState(health.HealthState_ERROR),
+				Message: &str,
+				Params: map[string]any{
+					"key": "uhoh",
+				},
+			},
+		},
+	}, keyedErrorSourceAccumulator.HealthStatus(context.Background()))
+}
+
+func TestKeyedErrorSourceAccumulatorRootUnderTreeUnhealthyParentBlocksChildren(t *testing.T) {
+	keyedErrorSourceAccumulator := NewDefaultKeyedErrorSourceAccumulator(MustNewKeyedErrorHealthCheckSource("check", UnhealthyIfAtLeastOneError))
+	unhealthyParent := health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"PARENT": {
+				Type:  "PARENT",
+				State: health.New_HealthState(health.HealthState_ERROR),
+			},
+		},
+	}
+	keyedErrorSourceAccumulator.RootUnderTree(sources.StaticHealthCheckSource(unhealthyParent))
+	keyedErrorSourceAccumulator.Submit(context.Background(), "key", errors.New("uhoh"))
+	assert.Equal(t, unhealthyParent, keyedErrorSourceAccumulator.HealthStatus(context.Background()))
+}
+
+func TestKeyedErrorSourceAccumulatorRootUnderTreeReplacesPriorRoot(t *testing.T) {
+	keyedErrorSourceAccumulator := NewDefaultKeyedErrorSourceAccumulator(MustNewKeyedErrorHealthCheckSource("check", UnhealthyIfAtLeastOneError))
+	keyedErrorSourceAccumulator.RootUnderTree(sources.StaticHealthCheckSource(health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"FIRST": sources.HealthyHealthCheckResult("FIRST"),
+		},
+	}))
+	keyedErrorSourceAccumulator.RootUnderTree(sources.StaticHealthCheckSource(health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"SECOND": sources.HealthyHealthCheckResult("SECOND"),
+		},
+	}))
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"SECOND": sources.HealthyHealthCheckResult("SECOND"),
+			"check":  sources.HealthyHealthCheckResult("check"),
 		},
 	}, keyedErrorSourceAccumulator.HealthStatus(context.Background()))
 }


### PR DESCRIPTION
- Add more flexibility to the KeyedErrorSourceAccumulator to allow for rooting it under a delegating health check if needed
- This allows us to tweak a given health check without forcing all parents to update or pass one in
