### PR TITLE
Avoid mutating parent health check maps

### DIFF
--- a/sources/tree/tree.go
+++ b/sources/tree/tree.go
@@ -74,12 +74,16 @@ func NewHealthCheckSourceTree(
 
 func (n *healthCheckSourceTreeNode) HealthStatus(ctx context.Context) health.HealthStatus {
 	ownHealthStatus := n.healthCheckSource.HealthStatus(ctx)
+	result := health.HealthStatus{
+		Checks: make(map[health.CheckType]health.HealthCheckResult, len(ownHealthStatus.Checks)),
+	}
+	maps.Copy(result.Checks, ownHealthStatus.Checks)
 	if !n.traverseForHealthState(ownHealthStatus) {
-		return ownHealthStatus
+		return result
 	}
 	healthStatusFromChildSources := n.combinedChildrenHealthCheckSource.HealthStatus(ctx)
-	maps.Copy(ownHealthStatus.Checks, healthStatusFromChildSources.Checks)
-	return ownHealthStatus
+	maps.Copy(result.Checks, healthStatusFromChildSources.Checks)
+	return result
 }
 
 func healthStateFromChecks(checks map[health.CheckType]health.HealthCheckResult) health.HealthState {

--- a/sources/tree/tree.go
+++ b/sources/tree/tree.go
@@ -53,7 +53,7 @@ func WithTraverseForHealthStatus(fn TraverseForHealthStatus) CheckSourceTreePara
 	})
 }
 
-// NewHealthCheckSourceTree returns a new health check source tree node that uses the result of its own healt h check
+// NewHealthCheckSourceTree returns a new health check source tree node that uses the result of its own health check
 // to determine if it should invoke the provided child health checks. The default behavior is to only traverse to child
 // checks if the most severe health state of the current node's health status is health.HealthState_HEALTHY.
 func NewHealthCheckSourceTree(

--- a/sources/tree/tree.go
+++ b/sources/tree/tree.go
@@ -53,7 +53,7 @@ func WithTraverseForHealthStatus(fn TraverseForHealthStatus) CheckSourceTreePara
 	})
 }
 
-// NewHealthCheckSourceTree returns a new health check source tree node that uses the result of its own health check
+// NewHealthCheckSourceTree returns a new health check source tree node that uses the result of its own healt h check
 // to determine if it should invoke the provided child health checks. The default behavior is to only traverse to child
 // checks if the most severe health state of the current node's health status is health.HealthState_HEALTHY.
 func NewHealthCheckSourceTree(

--- a/sources/tree/tree_test.go
+++ b/sources/tree/tree_test.go
@@ -76,6 +76,35 @@ func TestHealthCheckSourceTree(t *testing.T) {
 	}, treeSource.HealthStatus(context.Background()))
 }
 
+func TestHealthCheckSourceTreeDoesNotMutateParentChecksMap(t *testing.T) {
+	parentChecks := map[health.CheckType]health.HealthCheckResult{}
+	parentCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+		return health.HealthStatus{
+			Checks: parentChecks,
+		}
+	})
+	childCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+		return health.HealthStatus{
+			Checks: map[health.CheckType]health.HealthCheckResult{
+				"CHILD": {
+					State: health.New_HealthState(health.HealthState_ERROR),
+				},
+			},
+		}
+	})
+
+	treeSource := tree.NewHealthCheckSourceTree(parentCheck, []status.HealthCheckSource{childCheck})
+
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"CHILD": {
+				State: health.New_HealthState(health.HealthState_ERROR),
+			},
+		},
+	}, treeSource.HealthStatus(context.Background()))
+	assert.Empty(t, parentChecks)
+}
+
 func TestHealthCheckSourceTreeWithTraverseForHealthState(t *testing.T) {
 	dummyChildCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
 		return health.HealthStatus{

--- a/sources/window/keyed_error_source_accumulator_test.go
+++ b/sources/window/keyed_error_source_accumulator_test.go
@@ -42,6 +42,31 @@ func TestKeyedErrorSourceAccumulatorCanError(t *testing.T) {
 	}, keyedErrorSourceAccumulator.HealthStatus(context.Background()))
 }
 
+func TestKeyedErrorSourceAccumulatorRecoversAfterHealthStatusRead(t *testing.T) {
+	keyedErrorSourceAccumulator := NewDefaultKeyedErrorSourceAccumulator(MustNewKeyedErrorHealthCheckSource("HUB_AUTH", HealthyIfNotAllErrors))
+	keyedErrorSourceAccumulator.Submit(context.Background(), "TOKEN_PROVIDER_ITERATION", errors.New("uhoh"))
+	str := ""
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"HUB_AUTH": {
+				Type:    "HUB_AUTH",
+				State:   health.New_HealthState(health.HealthState_ERROR),
+				Message: &str,
+				Params: map[string]any{
+					"TOKEN_PROVIDER_ITERATION": "uhoh",
+				},
+			},
+		},
+	}, keyedErrorSourceAccumulator.HealthStatus(context.Background()))
+
+	keyedErrorSourceAccumulator.Submit(context.Background(), "TOKEN_PROVIDER_ITERATION", nil)
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"HUB_AUTH": sources.HealthyHealthCheckResult("HUB_AUTH"),
+		},
+	}, keyedErrorSourceAccumulator.HealthStatus(context.Background()))
+}
+
 func TestKeyedErrorSourceAccumulatorCanAdd(t *testing.T) {
 	keyedErrorSourceAccumulator := NewDefaultKeyedErrorSourceAccumulator(MustNewKeyedErrorHealthCheckSource("check", UnhealthyIfAtLeastOneError))
 	assert.Equal(t, health.HealthStatus{


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`HealthCheckSourceTree` could mutate a parent source’s shared `Checks` map when merging child health checks. If the parent returned a cached/static `HealthStatus`, a child error could poison the parent map, causing later health reads to see the parent as unhealthy and stop traversing to children.


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
`HealthCheckSourceTree` now builds a fresh result map before copying parent and child checks, so source-owned maps are not mutated during reads.
Added regression coverage for direct parent map mutation and the `HUB_AUTH` accumulator recovery path where an error read is followed by `Submit(nil)` returning healthy.

Fixes bug introduced here: https://github.com/palantir/witchcraft-go-health/pull/386

