### PR TITLE
✨ add HealthCheckSourceFunc to simplify creating HealthCheckSource from functions.

### DIFF
--- a/sources/downgrading/health_check_test.go
+++ b/sources/downgrading/health_check_test.go
@@ -19,14 +19,9 @@ import (
 	"testing"
 
 	"github.com/palantir/witchcraft-go-health/v2/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-health/v2/status"
 	"github.com/stretchr/testify/assert"
 )
-
-type healthStatusFn func(ctx context.Context) health.HealthStatus
-
-func (fn healthStatusFn) HealthStatus(ctx context.Context) health.HealthStatus {
-	return fn(ctx)
-}
 
 func TestDeferringHealthCheck(t *testing.T) {
 	expected := health.HealthStatus{
@@ -36,7 +31,7 @@ func TestDeferringHealthCheck(t *testing.T) {
 			},
 		},
 	}
-	healthCheckSource := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+	healthCheckSource := status.HealthCheckSourceFunc(func(ctx context.Context) health.HealthStatus {
 		return expected
 	})
 	healthCheck := NewDowngradingHealthCheck(healthCheckSource, health.HealthState_DEFERRING)
@@ -65,7 +60,7 @@ func TestDeferringHealthCheckDowngrades(t *testing.T) {
 			},
 		},
 	}
-	healthCheckSource := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+	healthCheckSource := status.HealthCheckSourceFunc(func(ctx context.Context) health.HealthStatus {
 		return toReturn
 	})
 	healthCheck := NewDowngradingHealthCheck(healthCheckSource, health.HealthState_DEFERRING)

--- a/sources/tree/tree_test.go
+++ b/sources/tree/tree_test.go
@@ -24,21 +24,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type healthStatusFn func(ctx context.Context) health.HealthStatus
-
-func (fn healthStatusFn) HealthStatus(ctx context.Context) health.HealthStatus {
-	return fn(ctx)
-}
-
 func TestHealthCheckSourceTree(t *testing.T) {
-	someChildCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+	someChildCheck := status.HealthCheckSourceFunc(func(ctx context.Context) health.HealthStatus {
 		return health.HealthStatus{
 			Checks: map[health.CheckType]health.HealthCheckResult{
 				"CHILD": {},
 			},
 		}
 	})
-	alwaysErrParentCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+	alwaysErrParentCheck := status.HealthCheckSourceFunc(func(ctx context.Context) health.HealthStatus {
 		return health.HealthStatus{
 			Checks: map[health.CheckType]health.HealthCheckResult{
 				"PARENT": {
@@ -56,7 +50,7 @@ func TestHealthCheckSourceTree(t *testing.T) {
 		},
 	}, treeSource.HealthStatus(context.Background()))
 
-	healthyParentCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+	healthyParentCheck := status.HealthCheckSourceFunc(func(ctx context.Context) health.HealthStatus {
 		return health.HealthStatus{
 			Checks: map[health.CheckType]health.HealthCheckResult{
 				"PARENT": {
@@ -78,12 +72,12 @@ func TestHealthCheckSourceTree(t *testing.T) {
 
 func TestHealthCheckSourceTreeDoesNotMutateParentChecksMap(t *testing.T) {
 	parentChecks := map[health.CheckType]health.HealthCheckResult{}
-	parentCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+	parentCheck := status.HealthCheckSourceFunc(func(ctx context.Context) health.HealthStatus {
 		return health.HealthStatus{
 			Checks: parentChecks,
 		}
 	})
-	childCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+	childCheck := status.HealthCheckSourceFunc(func(ctx context.Context) health.HealthStatus {
 		return health.HealthStatus{
 			Checks: map[health.CheckType]health.HealthCheckResult{
 				"CHILD": {
@@ -106,7 +100,7 @@ func TestHealthCheckSourceTreeDoesNotMutateParentChecksMap(t *testing.T) {
 }
 
 func TestHealthCheckSourceTreeWithTraverseForHealthState(t *testing.T) {
-	dummyChildCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+	dummyChildCheck := status.HealthCheckSourceFunc(func(ctx context.Context) health.HealthStatus {
 		return health.HealthStatus{
 			Checks: map[health.CheckType]health.HealthCheckResult{
 				"CHILD_CHECK": {
@@ -115,7 +109,7 @@ func TestHealthCheckSourceTreeWithTraverseForHealthState(t *testing.T) {
 			},
 		}
 	})
-	unhealthyParentCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+	unhealthyParentCheck := status.HealthCheckSourceFunc(func(ctx context.Context) health.HealthStatus {
 		return health.HealthStatus{
 			Checks: map[health.CheckType]health.HealthCheckResult{
 				"TEST_CHECK": {

--- a/status/status.go
+++ b/status/status.go
@@ -54,6 +54,18 @@ type HealthCheckSource interface {
 	HealthStatus(ctx context.Context) health.HealthStatus
 }
 
+// HealthCheckSourceFunc is a function that implements HealthCheckSource.
+type HealthCheckSourceFunc func(ctx context.Context) health.HealthStatus
+
+// HealthStatus implements HealthCheckSource by calling f(ctx). A nil HealthCheckSourceFunc
+// reports an empty health.HealthStatus.
+func (f HealthCheckSourceFunc) HealthStatus(ctx context.Context) health.HealthStatus {
+	if f == nil {
+		return health.HealthStatus{}
+	}
+	return f(ctx)
+}
+
 type combinedHealthCheckSource struct {
 	healthCheckSources refreshable.Refreshable[[]HealthCheckSource]
 }

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -284,3 +284,29 @@ func TestHealthBasedReadinessSource(t *testing.T) {
 		})
 	}
 }
+
+func TestHealthCheckSourceFunc(t *testing.T) {
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "sentinel")
+	expected := health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"check": {
+				State: health.New_HealthState(health.HealthState_HEALTHY),
+			},
+		},
+	}
+
+	var gotCtx context.Context
+	var source HealthCheckSource = HealthCheckSourceFunc(func(ctx context.Context) health.HealthStatus {
+		gotCtx = ctx
+		return expected
+	})
+
+	assert.Equal(t, expected, source.HealthStatus(ctx))
+	assert.Equal(t, ctx, gotCtx)
+}
+
+func TestHealthCheckSourceFuncNil(t *testing.T) {
+	var source HealthCheckSource = HealthCheckSourceFunc(nil)
+	assert.Equal(t, health.HealthStatus{}, source.HealthStatus(context.Background()))
+}

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -296,14 +296,12 @@ func TestHealthCheckSourceFunc(t *testing.T) {
 		},
 	}
 
-	var gotCtx context.Context
-	var source HealthCheckSource = HealthCheckSourceFunc(func(ctx context.Context) health.HealthStatus {
-		gotCtx = ctx
+	var source HealthCheckSource = HealthCheckSourceFunc(func(gotCtx context.Context) health.HealthStatus {
+		assert.Equal(t, ctx, gotCtx)
 		return expected
 	})
 
 	assert.Equal(t, expected, source.HealthStatus(ctx))
-	assert.Equal(t, ctx, gotCtx)
 }
 
 func TestHealthCheckSourceFuncNil(t *testing.T) {


### PR DESCRIPTION
## Before this PR
A `status.HealthCheckSource` that is just a function returning a `health.HealthStatus` still has to be wrapped in a one-method struct. This repo's own tests do exactly that: `sources/tree` and `sources/downgrading` both declare a `healthStatusFn` helper.

## After this PR
Adds `status.HealthCheckSourceFunc`, a function type that implements `status.HealthCheckSource` by calling itself. A nil `HealthCheckSourceFunc` reports an empty `health.HealthStatus`. Purely additive and backwards-compatible. Also dogfoods it: the duplicated `healthStatusFn` test helpers in `sources/tree` and `sources/downgrading` are deleted in favour of the new type.

**Example 1 — an atomic, precomputed status source:**

    var current atomic.Pointer[health.HealthStatus]
    current.Store(&initialStatus)
    // elsewhere, whenever state changes: current.Store(&newStatus)

    var source status.HealthCheckSource = status.HealthCheckSourceFunc(
        func(context.Context) health.HealthStatus { return *current.Load() },
    )

**Example 2 — a trivial anonymous func computing from a stored value:**

    var started atomic.Bool // flipped true once startup completes

    var source status.HealthCheckSource = status.HealthCheckSourceFunc(
        func(context.Context) health.HealthStatus {
            const checkType health.CheckType = "STARTUP"
            result := sources.HealthyHealthCheckResult(checkType)
            if !started.Load() {
                result = sources.RepairingHealthCheckResult(checkType, "startup in progress", nil)
            }
            return health.HealthStatus{Checks: map[health.CheckType]health.HealthCheckResult{checkType: result}}
        },
    )

## Possible downsides?
None — purely additive; no existing API changes.
